### PR TITLE
feat: 보드 삭제 API 구현 #14

### DIFF
--- a/apps/server/src/modules/boards/boards.types.ts
+++ b/apps/server/src/modules/boards/boards.types.ts
@@ -131,6 +131,24 @@ export interface UpdateBoardResponse {
   timestamp: string;
 }
 
+// 보드 삭제 요청 파라미터
+export interface DeleteBoardParams {
+  boardId: string;
+}
+
+// 삭제된 보드 정보
+export interface DeletedBoard {
+  id: string;
+  deletedAt: string;
+}
+
+// 보드 삭제 응답
+export interface DeleteBoardResponse {
+  success: boolean;
+  data: DeletedBoard;
+  timestamp: string;
+}
+
 // 에러 응답
 export interface ErrorResponse {
   success: boolean;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 보드 소유자가 보드를 삭제할 수 있는 기능이 추가되었습니다. 보드 삭제 시 연관된 모든 목록, 카드, 레이블, 멤버 항목도 함께 자동으로 제거됩니다. 삭제 완료 후 보드 ID와 정확한 삭제 시간이 포함된 응답을 받을 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->