### PR TITLE
Feat/24 보드 카드 컴포넌트 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+docs

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,6 +6,7 @@ import RegisterPage from '@/app/(auth)/register/page';
 import { ProtectedRoute } from '@/domains/auth/components';
 import { PageLayout } from '@/components/layout';
 import DashboardPage from './app/dashboard/page';
+import BoardDetailPage from './app/boards/detail/page';
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
             <Route path="/login" element={<LoginPage />} />
             <Route path="/register" element={<RegisterPage />} />
             <Route path="/dashboard" element={<DashboardPage />} />
+            <Route path="/boards/:boardId" element={<BoardDetailPage />} />
 
             {/* 인증 필요 라우트 */}
             {/** <Route

--- a/apps/web/src/app/boards/detail/page.tsx
+++ b/apps/web/src/app/boards/detail/page.tsx
@@ -1,0 +1,8 @@
+import { useParams } from 'react-router-dom';
+
+function BoardDetailPage() {
+  const { boardId } = useParams();
+  return <div>BoardDetail: {boardId}</div>;
+}
+
+export default BoardDetailPage;

--- a/apps/web/src/domains/boards/components/BoardCard.tsx
+++ b/apps/web/src/domains/boards/components/BoardCard.tsx
@@ -28,6 +28,7 @@ const INFO_HEIGHT_PX = 60;
 export function BoardCard({ board, onEdit, onDelete }: BoardCardProps) {
   const navigate = useNavigate();
   const [isHovered, setIsHovered] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
 
   const showRecentBadge = isRecentlyAccessed(board.lastAccessedAt);
   const relativeTime = formatRelativeTime(board.updatedAt);
@@ -64,12 +65,18 @@ export function BoardCard({ board, onEdit, onDelete }: BoardCardProps) {
         'shadow-md hover:shadow-lg',
         'transition-all duration-150 ease-out',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2',
-        isHovered && 'transform -translate-y-0.5 scale-[1.02]',
+        (isHovered || isFocused) && 'transform -translate-y-0.5 scale-[1.02]',
       )}
       onClick={handleCardClick}
       onKeyDown={handleKeyDown}
       onPointerEnter={() => setIsHovered(true)}
       onPointerLeave={() => setIsHovered(false)}
+      onFocus={() => setIsFocused(true)}
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+          setIsFocused(false);
+        }
+      }}
     >
       {/* 배경색 영역 */}
       <div
@@ -83,7 +90,7 @@ export function BoardCard({ board, onEdit, onDelete }: BoardCardProps) {
         <div
           className={cn(
             'absolute top-2 right-2 transition-opacity duration-150',
-            isHovered ? 'opacity-100' : 'opacity-0',
+            isHovered || isFocused ? 'opacity-100' : 'opacity-0',
           )}
         >
           <BoardCardMenu onEdit={handleEdit} onDelete={handleDelete} />

--- a/apps/web/src/domains/boards/components/BoardCard.tsx
+++ b/apps/web/src/domains/boards/components/BoardCard.tsx
@@ -1,0 +1,118 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
+import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { cn } from '@/lib/utils/cn';
+import { BoardCardMenu } from '@/domains/boards/components/BoardCardMenu';
+import { RecentAccessBadge } from '@/domains/boards/components/RecentAccessBadge';
+import { formatRelativeTime } from '@/domains/boards/utils/formatRelativeTime';
+import { isRecentlyAccessed } from '@/domains/boards/utils/isRecentlyAccessed';
+
+export interface BoardCardData {
+  id: string;
+  title: string;
+  backgroundColor: string;
+  updatedAt: string;
+  lastAccessedAt: string | null;
+}
+
+interface BoardCardProps {
+  board: BoardCardData;
+  onEdit: (boardId: string) => void;
+  onDelete: (boardId: string) => void;
+}
+
+const BACKGROUND_HEIGHT_PX = 100;
+const INFO_HEIGHT_PX = 60;
+
+export function BoardCard({ board, onEdit, onDelete }: BoardCardProps) {
+  const navigate = useNavigate();
+  const [isHovered, setIsHovered] = useState(false);
+
+  const showRecentBadge = isRecentlyAccessed(board.lastAccessedAt);
+  const relativeTime = formatRelativeTime(board.updatedAt);
+
+  const handleCardClick = useCallback(() => {
+    navigate(`/boards/${board.id}`);
+  }, [navigate, board.id]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        handleCardClick();
+      }
+    },
+    [handleCardClick],
+  );
+
+  const handleEdit = useCallback(() => {
+    onEdit(board.id);
+  }, [onEdit, board.id]);
+
+  const handleDelete = useCallback(() => {
+    onDelete(board.id);
+  }, [onDelete, board.id]);
+
+  return (
+    <article
+      role="button"
+      aria-label={`보드: ${board.title}`}
+      tabIndex={0}
+      className={cn(
+        'rounded-lg overflow-hidden cursor-pointer',
+        'shadow-md hover:shadow-lg',
+        'transition-all duration-150 ease-out',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2',
+        isHovered && 'transform -translate-y-0.5 scale-[1.02]',
+      )}
+      onClick={handleCardClick}
+      onKeyDown={handleKeyDown}
+      onPointerEnter={() => setIsHovered(true)}
+      onPointerLeave={() => setIsHovered(false)}
+    >
+      {/* 배경색 영역 */}
+      <div
+        className="relative"
+        style={{
+          backgroundColor: board.backgroundColor,
+          height: `${BACKGROUND_HEIGHT_PX}px`,
+        }}
+      >
+        {/* 더보기 버튼 - 호버 시에만 표시 */}
+        <div
+          className={cn(
+            'absolute top-2 right-2 transition-opacity duration-150',
+            isHovered ? 'opacity-100' : 'opacity-0',
+          )}
+        >
+          <BoardCardMenu onEdit={handleEdit} onDelete={handleDelete} />
+        </div>
+      </div>
+
+      {/* 정보 영역 */}
+      <div
+        className={cn(
+          'bg-white dark:bg-slate-800 px-4 py-3',
+          'flex flex-col justify-center',
+        )}
+        style={{ height: `${INFO_HEIGHT_PX}px` }}
+      >
+        <div className="flex items-center justify-between gap-2">
+          <h3
+            className={cn(
+              'text-sm font-semibold truncate',
+              'text-gray-900 dark:text-gray-100',
+            )}
+          >
+            {board.title}
+          </h3>
+          {showRecentBadge && <RecentAccessBadge />}
+        </div>
+        <p className="text-right text-xs text-gray-500 dark:text-gray-400 mt-1">
+          {relativeTime}
+        </p>
+      </div>
+    </article>
+  );
+}

--- a/apps/web/src/domains/boards/components/BoardCardMenu.tsx
+++ b/apps/web/src/domains/boards/components/BoardCardMenu.tsx
@@ -1,0 +1,82 @@
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
+import { MoreVertical, Pencil, Trash2 } from 'lucide-react';
+
+import { cn } from '@/lib/utils/cn';
+
+interface BoardCardMenuProps {
+  onEdit: () => void;
+  onDelete: () => void;
+  className?: string;
+}
+
+export function BoardCardMenu({
+  onEdit,
+  onDelete,
+  className,
+}: BoardCardMenuProps) {
+  return (
+    <Menu as="div" className={cn('relative', className)}>
+      <MenuButton
+        className={cn(
+          'p-1.5 rounded-md transition-colors',
+          'text-white/80 hover:text-white hover:bg-black/20',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50',
+        )}
+        aria-label="보드 옵션"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <MoreVertical className="w-4 h-4" />
+      </MenuButton>
+
+      <MenuItems
+        className={cn(
+          'absolute right-0 mt-1 w-36 z-50',
+          'bg-white rounded-lg shadow-lg ring-1 ring-black/5',
+          'dark:bg-slate-800 dark:ring-white/10',
+          'focus:outline-none',
+          'origin-top-right',
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="py-1">
+          <MenuItem>
+            {({ focus }) => (
+              <button
+                type="button"
+                className={cn(
+                  'flex items-center gap-2 w-full px-3 py-2 text-sm text-left',
+                  'transition-colors',
+                  focus
+                    ? 'bg-slate-100 text-slate-900 dark:bg-slate-700 dark:text-white'
+                    : 'text-slate-700 dark:text-slate-200',
+                )}
+                onClick={onEdit}
+              >
+                <Pencil className="w-4 h-4" />
+                수정
+              </button>
+            )}
+          </MenuItem>
+          <MenuItem>
+            {({ focus }) => (
+              <button
+                type="button"
+                className={cn(
+                  'flex items-center gap-2 w-full px-3 py-2 text-sm text-left',
+                  'transition-colors',
+                  focus
+                    ? 'bg-red-50 text-red-600 dark:bg-red-900/20 dark:text-red-400'
+                    : 'text-red-600 dark:text-red-400',
+                )}
+                onClick={onDelete}
+              >
+                <Trash2 className="w-4 h-4" />
+                삭제
+              </button>
+            )}
+          </MenuItem>
+        </div>
+      </MenuItems>
+    </Menu>
+  );
+}

--- a/apps/web/src/domains/boards/components/BoardCardSkeleton.tsx
+++ b/apps/web/src/domains/boards/components/BoardCardSkeleton.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/utils/cn';
+
+const BACKGROUND_HEIGHT_PX = 100;
+const INFO_HEIGHT_PX = 60;
+
+interface BoardCardSkeletonProps {
+  className?: string;
+}
+
+export function BoardCardSkeleton({ className }: BoardCardSkeletonProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-lg overflow-hidden shadow-md',
+        'animate-pulse',
+        className,
+      )}
+    >
+      {/* 배경색 영역 스켈레톤 */}
+      <div
+        className="bg-gray-200 dark:bg-gray-700"
+        style={{ height: `${BACKGROUND_HEIGHT_PX}px` }}
+      />
+
+      {/* 정보 영역 스켈레톤 */}
+      <div
+        className={cn(
+          'bg-white dark:bg-slate-800 px-4 py-3',
+          'flex flex-col justify-center',
+        )}
+        style={{ height: `${INFO_HEIGHT_PX}px` }}
+      >
+        <div className="flex items-center justify-between gap-2">
+          {/* 제목 스켈레톤 */}
+          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/5" />
+          {/* 뱃지 스켈레톤 */}
+          <div className="h-5 bg-gray-200 dark:bg-gray-700 rounded-full w-16" />
+        </div>
+        {/* 시간 스켈레톤 */}
+        <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-1/4 mt-2" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/domains/boards/components/BoardGrid.tsx
+++ b/apps/web/src/domains/boards/components/BoardGrid.tsx
@@ -1,9 +1,22 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import { type BoardSummary } from '@/domains/boards/hooks/useBoards';
 import { BoardLoadingSpinner } from '@/domains/boards/components/BoardLoadingSpinner';
+import { BoardCard } from '@/domains/boards/components/BoardCard';
+import { BoardCardSkeleton } from '@/domains/boards/components/BoardCardSkeleton';
 import { useInfiniteBoards } from '@/domains/boards/hooks/useInfiniteBoards';
+
+const SKELETON_IDS = [
+  'skeleton-1',
+  'skeleton-2',
+  'skeleton-3',
+  'skeleton-4',
+  'skeleton-5',
+  'skeleton-6',
+  'skeleton-7',
+  'skeleton-8',
+] as const;
 
 function BoardGrid() {
   const {
@@ -26,14 +39,38 @@ function BoardGrid() {
     }
   }, [inView, hasNextPage, fetchNextPage]);
 
-  if (isLoading)
-    // eslint-disable-next-line @stylistic/nonblock-statement-body-position
+  const handleEditBoard = useCallback((_boardId: string) => {
+    // TODO: 보드 수정 모달 열기
+  }, []);
+
+  const handleDeleteBoard = useCallback((_boardId: string) => {
+    // TODO: 보드 삭제 확인 모달 열기
+  }, []);
+
+  if (isLoading) {
     return (
-      <div className="flex justify-center items-center h-full">
-        <BoardLoadingSpinner label="보드를 불러오는 중..." />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        {SKELETON_IDS.map((id) => (
+          <BoardCardSkeleton key={id} />
+        ))}
       </div>
     );
-  if (error) return <div>Error: {error.message}</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="text-center">
+          <p className="text-red-600 dark:text-red-400 font-medium">
+            오류가 발생했습니다
+          </p>
+          <p className="text-gray-500 dark:text-gray-400 text-sm mt-1">
+            {error.message}
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   const boards: BoardSummary[] =
     data?.pages
@@ -41,18 +78,25 @@ function BoardGrid() {
       .flatMap((page) => (page.success ? page.data.items : [])) ?? [];
 
   if (boards.length === 0) {
-    return <div>No boards found</div>;
+    return (
+      <div className="flex justify-center items-center h-64">
+        <p className="text-gray-500 dark:text-gray-400">
+          보드가 없습니다. 새 보드를 만들어보세요!
+        </p>
+      </div>
+    );
   }
 
   return (
     <>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         {boards.map((board: BoardSummary) => (
-          <div key={board.id} className="col-span-1">
-            <div className="bg-white rounded-lg shadow-md p-4">
-              <h3 className="text-lg font-medium">{board.title}</h3>
-            </div>
-          </div>
+          <BoardCard
+            key={board.id}
+            board={board}
+            onEdit={handleEditBoard}
+            onDelete={handleDeleteBoard}
+          />
         ))}
       </div>
       <div ref={sentinelRef} />

--- a/apps/web/src/domains/boards/components/RecentAccessBadge.tsx
+++ b/apps/web/src/domains/boards/components/RecentAccessBadge.tsx
@@ -8,7 +8,7 @@ export function RecentAccessBadge({ className }: RecentAccessBadgeProps) {
   return (
     <span
       className={cn(
-        'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium',
+        'inline-flex items-center ml-2 py-0.5 rounded-full text-xs text-right font-medium',
         'bg-blue-100 text-blue-700',
         'dark:bg-blue-900/30 dark:text-blue-300',
         className,

--- a/apps/web/src/domains/boards/components/RecentAccessBadge.tsx
+++ b/apps/web/src/domains/boards/components/RecentAccessBadge.tsx
@@ -1,0 +1,20 @@
+import { cn } from '@/lib/utils/cn';
+
+interface RecentAccessBadgeProps {
+  className?: string;
+}
+
+export function RecentAccessBadge({ className }: RecentAccessBadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium',
+        'bg-blue-100 text-blue-700',
+        'dark:bg-blue-900/30 dark:text-blue-300',
+        className,
+      )}
+    >
+      최근 접속
+    </span>
+  );
+}

--- a/apps/web/src/domains/boards/components/RecentAccessBadge.tsx
+++ b/apps/web/src/domains/boards/components/RecentAccessBadge.tsx
@@ -10,7 +10,7 @@ export function RecentAccessBadge({ className }: RecentAccessBadgeProps) {
       className={cn(
         'inline-flex items-center ml-2 py-0.5 text-xs text-right font-medium',
         'text-blue-700',
-        'dark:bg-blue-900/30 dark:text-blue-300',
+        'dark:text-blue-300',
         className,
       )}
     >

--- a/apps/web/src/domains/boards/components/RecentAccessBadge.tsx
+++ b/apps/web/src/domains/boards/components/RecentAccessBadge.tsx
@@ -8,8 +8,8 @@ export function RecentAccessBadge({ className }: RecentAccessBadgeProps) {
   return (
     <span
       className={cn(
-        'inline-flex items-center ml-2 py-0.5 rounded-full text-xs text-right font-medium',
-        'bg-blue-100 text-blue-700',
+        'inline-flex items-center ml-2 py-0.5 text-xs text-right font-medium',
+        'text-blue-700',
         'dark:bg-blue-900/30 dark:text-blue-300',
         className,
       )}

--- a/apps/web/src/domains/boards/components/__tests__/BoardCard.test.tsx
+++ b/apps/web/src/domains/boards/components/__tests__/BoardCard.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { BoardCard, type BoardCardData } from '../BoardCard';
+
+// react-router-dom의 useNavigate 모킹
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe('BoardCard', () => {
+  const DAY_MS = 1000 * 60 * 60 * 24;
+  const BASE_TIME = new Date('2025-01-07T12:00:00.000Z');
+
+  const createMockBoard = (
+    overrides?: Partial<BoardCardData>,
+  ): BoardCardData => ({
+    id: 'board-123',
+    title: '테스트 보드',
+    backgroundColor: '#0079BF',
+    updatedAt: new Date(BASE_TIME.getTime() - 3 * 60 * 60 * 1000).toISOString(), // 3시간 전
+    lastAccessedAt: new Date(BASE_TIME.getTime() - 2 * DAY_MS).toISOString(), // 2일 전
+    ...overrides,
+  });
+
+  const createDefaultProps = (boardOverrides?: Partial<BoardCardData>) => ({
+    board: createMockBoard(boardOverrides),
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+  });
+
+  const renderWithRouter = (ui: React.ReactElement) => {
+    return render(<MemoryRouter>{ui}</MemoryRouter>);
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIME);
+    mockNavigate.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('렌더링', () => {
+    it('보드 제목이 표시된다', () => {
+      // Given
+      const props = createDefaultProps({ title: '프로젝트 A' });
+
+      // When
+      renderWithRouter(<BoardCard {...props} />);
+
+      // Then
+      expect(screen.getByText('프로젝트 A')).toBeInTheDocument();
+    });
+
+    it('카드 배경에 선택된 배경색이 적용된다', () => {
+      // Given
+      const backgroundColor = '#FF5733';
+      const props = createDefaultProps({ backgroundColor });
+
+      // When
+      renderWithRouter(<BoardCard {...props} />);
+
+      // Then
+      const card = screen.getByRole('button', { name: /보드:/ });
+      const backgroundDiv = card.querySelector(
+        'div[style*="background-color"]',
+      );
+      expect(backgroundDiv).toHaveStyle({ backgroundColor });
+    });
+
+    it('최종 수정 시간이 상대적 시간으로 표시된다', () => {
+      // Given
+      const props = createDefaultProps();
+
+      // When
+      renderWithRouter(<BoardCard {...props} />);
+
+      // Then
+      expect(screen.getByText('3시간 전')).toBeInTheDocument();
+    });
+
+    it('최근 7일 이내 접속한 보드에 "최근 접속" 뱃지가 표시된다', () => {
+      // Given
+      const props = createDefaultProps({
+        lastAccessedAt: new Date(
+          BASE_TIME.getTime() - 2 * DAY_MS,
+        ).toISOString(), // 2일 전
+      });
+
+      // When
+      renderWithRouter(<BoardCard {...props} />);
+
+      // Then
+      expect(screen.getByText('최근 접속')).toBeInTheDocument();
+    });
+
+    it('7일 초과 접속한 보드에는 "최근 접속" 뱃지가 표시되지 않는다', () => {
+      // Given
+      const props = createDefaultProps({
+        lastAccessedAt: new Date(
+          BASE_TIME.getTime() - 10 * DAY_MS,
+        ).toISOString(), // 10일 전
+      });
+
+      // When
+      renderWithRouter(<BoardCard {...props} />);
+
+      // Then
+      expect(screen.queryByText('최근 접속')).not.toBeInTheDocument();
+    });
+
+    it('lastAccessedAt이 null이면 "최근 접속" 뱃지가 표시되지 않는다', () => {
+      // Given
+      const props = createDefaultProps({ lastAccessedAt: null });
+
+      // When
+      renderWithRouter(<BoardCard {...props} />);
+
+      // Then
+      expect(screen.queryByText('최근 접속')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('접근성', () => {
+    it('role="button"과 aria-label이 올바르게 설정된다', () => {
+      // Given
+      const props = createDefaultProps({ title: '테스트 보드' });
+
+      // When
+      renderWithRouter(<BoardCard {...props} />);
+
+      // Then
+      const card = screen.getByRole('button', { name: '보드: 테스트 보드' });
+      expect(card).toBeInTheDocument();
+    });
+
+    it('tabIndex=0으로 키보드 포커스가 가능하다', () => {
+      // Given
+      const props = createDefaultProps();
+
+      // When
+      renderWithRouter(<BoardCard {...props} />);
+
+      // Then
+      const card = screen.getByRole('button', { name: /보드:/ });
+      expect(card).toHaveAttribute('tabIndex', '0');
+    });
+  });
+
+  describe('클릭 동작', () => {
+    it('카드 클릭 시 해당 보드 페이지로 이동한다', async () => {
+      // Given
+      vi.useRealTimers(); // userEvent와 fake timers 충돌 방지
+      const user = userEvent.setup();
+      const props = createDefaultProps({ id: 'board-456' });
+      renderWithRouter(<BoardCard {...props} />);
+
+      // When
+      await user.click(screen.getByRole('button', { name: /보드:/ }));
+
+      // Then
+      expect(mockNavigate).toHaveBeenCalledWith('/boards/board-456');
+    });
+  });
+
+  describe('키보드 동작', () => {
+    it('Enter 키 입력 시 해당 보드 페이지로 이동한다', async () => {
+      // Given
+      vi.useRealTimers(); // userEvent와 fake timers 충돌 방지
+      const user = userEvent.setup();
+      const props = createDefaultProps({ id: 'board-789' });
+      renderWithRouter(<BoardCard {...props} />);
+
+      // When
+      const card = screen.getByRole('button', { name: /보드:/ });
+      card.focus();
+      await user.keyboard('{Enter}');
+
+      // Then
+      expect(mockNavigate).toHaveBeenCalledWith('/boards/board-789');
+    });
+  });
+
+  describe('더보기 메뉴', () => {
+    it('더보기 버튼이 렌더링된다', () => {
+      // Given
+      const props = createDefaultProps();
+
+      // When
+      renderWithRouter(<BoardCard {...props} />);
+
+      // Then
+      expect(
+        screen.getByRole('button', { name: '보드 옵션' }),
+      ).toBeInTheDocument();
+    });
+
+    it('수정 버튼 클릭 시 onEdit 콜백이 보드 ID와 함께 호출된다', async () => {
+      // Given
+      vi.useRealTimers(); // userEvent와 fake timers 충돌 방지
+      const user = userEvent.setup();
+      const props = createDefaultProps({ id: 'board-edit-test' });
+      renderWithRouter(<BoardCard {...props} />);
+
+      // When
+      await user.click(screen.getByRole('button', { name: '보드 옵션' }));
+      await user.click(screen.getByRole('menuitem', { name: '수정' }));
+
+      // Then
+      expect(props.onEdit).toHaveBeenCalledWith('board-edit-test');
+    });
+
+    it('삭제 버튼 클릭 시 onDelete 콜백이 보드 ID와 함께 호출된다', async () => {
+      // Given
+      vi.useRealTimers(); // userEvent와 fake timers 충돌 방지
+      const user = userEvent.setup();
+      const props = createDefaultProps({ id: 'board-delete-test' });
+      renderWithRouter(<BoardCard {...props} />);
+
+      // When
+      await user.click(screen.getByRole('button', { name: '보드 옵션' }));
+      await user.click(screen.getByRole('menuitem', { name: '삭제' }));
+
+      // Then
+      expect(props.onDelete).toHaveBeenCalledWith('board-delete-test');
+    });
+  });
+});

--- a/apps/web/src/domains/boards/components/__tests__/BoardCardMenu.test.tsx
+++ b/apps/web/src/domains/boards/components/__tests__/BoardCardMenu.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BoardCardMenu } from '../BoardCardMenu';
+
+describe('BoardCardMenu', () => {
+  const createDefaultProps = () => ({
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+  });
+
+  describe('렌더링', () => {
+    it('더보기 버튼이 렌더링된다', () => {
+      // Given
+      const props = createDefaultProps();
+
+      // When
+      render(<BoardCardMenu {...props} />);
+
+      // Then
+      expect(
+        screen.getByRole('button', { name: '보드 옵션' }),
+      ).toBeInTheDocument();
+    });
+
+    it('더보기 버튼에 올바른 aria-label이 설정된다', () => {
+      // Given
+      const props = createDefaultProps();
+
+      // When
+      render(<BoardCardMenu {...props} />);
+
+      // Then
+      const button = screen.getByRole('button', { name: '보드 옵션' });
+      expect(button).toHaveAttribute('aria-label', '보드 옵션');
+    });
+  });
+
+  describe('드롭다운 메뉴', () => {
+    it('버튼 클릭 시 드롭다운 메뉴가 열린다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      render(<BoardCardMenu {...props} />);
+
+      // When
+      await user.click(screen.getByRole('button', { name: '보드 옵션' }));
+
+      // Then
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('드롭다운 메뉴에 수정 버튼이 표시된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      render(<BoardCardMenu {...props} />);
+
+      // When
+      await user.click(screen.getByRole('button', { name: '보드 옵션' }));
+
+      // Then
+      expect(
+        screen.getByRole('menuitem', { name: '수정' }),
+      ).toBeInTheDocument();
+    });
+
+    it('드롭다운 메뉴에 삭제 버튼이 표시된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      render(<BoardCardMenu {...props} />);
+
+      // When
+      await user.click(screen.getByRole('button', { name: '보드 옵션' }));
+
+      // Then
+      expect(
+        screen.getByRole('menuitem', { name: '삭제' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('콜백 함수 호출', () => {
+    it('수정 버튼 클릭 시 onEdit 콜백이 호출된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      render(<BoardCardMenu {...props} />);
+
+      // When
+      await user.click(screen.getByRole('button', { name: '보드 옵션' }));
+      await user.click(screen.getByRole('menuitem', { name: '수정' }));
+
+      // Then
+      expect(props.onEdit).toHaveBeenCalledTimes(1);
+    });
+
+    it('삭제 버튼 클릭 시 onDelete 콜백이 호출된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      render(<BoardCardMenu {...props} />);
+
+      // When
+      await user.click(screen.getByRole('button', { name: '보드 옵션' }));
+      await user.click(screen.getByRole('menuitem', { name: '삭제' }));
+
+      // Then
+      expect(props.onDelete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('이벤트 전파 방지', () => {
+    it('버튼 클릭 시 이벤트 전파가 중단된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const parentClickHandler = vi.fn();
+      const props = createDefaultProps();
+
+      render(
+        <button type="button" onClick={parentClickHandler}>
+          <BoardCardMenu {...props} />
+        </button>,
+      );
+
+      // When
+      await user.click(screen.getByRole('button', { name: '보드 옵션' }));
+
+      // Then
+      expect(parentClickHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('스타일', () => {
+    it('className prop으로 추가 스타일을 적용할 수 있다', () => {
+      // Given
+      const props = createDefaultProps();
+      const customClass = 'custom-menu-class';
+
+      // When
+      const { container } = render(
+        <BoardCardMenu {...props} className={customClass} />,
+      );
+
+      // Then
+      expect(container.firstChild).toHaveClass(customClass);
+    });
+  });
+});

--- a/apps/web/src/domains/boards/components/__tests__/BoardCardSkeleton.test.tsx
+++ b/apps/web/src/domains/boards/components/__tests__/BoardCardSkeleton.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { BoardCardSkeleton } from '../BoardCardSkeleton';
+
+describe('BoardCardSkeleton', () => {
+  describe('렌더링', () => {
+    it('스켈레톤 컨테이너가 렌더링된다', () => {
+      // When
+      const { container } = render(<BoardCardSkeleton />);
+
+      // Then
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it('카드와 동일한 높이 구조를 가진다 (배경 100px + 정보 60px)', () => {
+      // When
+      const { container } = render(<BoardCardSkeleton />);
+
+      // Then
+      const backgroundDiv = container.querySelector(
+        'div[style*="height: 100px"]',
+      );
+      const infoDiv = container.querySelector('div[style*="height: 60px"]');
+
+      expect(backgroundDiv).toBeInTheDocument();
+      expect(infoDiv).toBeInTheDocument();
+    });
+  });
+
+  describe('스타일', () => {
+    it('펄스 애니메이션 클래스가 적용된다', () => {
+      // When
+      const { container } = render(<BoardCardSkeleton />);
+
+      // Then
+      expect(container.firstChild).toHaveClass('animate-pulse');
+    });
+
+    it('둥근 모서리 클래스가 적용된다', () => {
+      // When
+      const { container } = render(<BoardCardSkeleton />);
+
+      // Then
+      expect(container.firstChild).toHaveClass('rounded-lg');
+    });
+
+    it('그림자 클래스가 적용된다', () => {
+      // When
+      const { container } = render(<BoardCardSkeleton />);
+
+      // Then
+      expect(container.firstChild).toHaveClass('shadow-md');
+    });
+
+    it('className prop으로 추가 스타일을 적용할 수 있다', () => {
+      // Given
+      const customClass = 'custom-skeleton-class';
+
+      // When
+      const { container } = render(
+        <BoardCardSkeleton className={customClass} />,
+      );
+
+      // Then
+      expect(container.firstChild).toHaveClass(customClass);
+    });
+  });
+
+  describe('스켈레톤 요소', () => {
+    it('배경 영역 스켈레톤이 표시된다', () => {
+      // When
+      const { container } = render(<BoardCardSkeleton />);
+
+      // Then
+      const backgroundSkeleton = container.querySelector('.bg-gray-200');
+      expect(backgroundSkeleton).toBeInTheDocument();
+    });
+
+    it('제목 스켈레톤이 표시된다', () => {
+      // When
+      const { container } = render(<BoardCardSkeleton />);
+
+      // Then
+      const titleSkeleton = container.querySelector('.w-3\\/5');
+      expect(titleSkeleton).toBeInTheDocument();
+      expect(titleSkeleton).toHaveClass('h-4');
+      expect(titleSkeleton).toHaveClass('rounded');
+    });
+
+    it('뱃지 스켈레톤이 표시된다', () => {
+      // When
+      const { container } = render(<BoardCardSkeleton />);
+
+      // Then
+      const badgeSkeleton = container.querySelector('.w-16');
+      expect(badgeSkeleton).toBeInTheDocument();
+      expect(badgeSkeleton).toHaveClass('rounded-full');
+    });
+
+    it('시간 스켈레톤이 표시된다', () => {
+      // When
+      const { container } = render(<BoardCardSkeleton />);
+
+      // Then
+      const timeSkeleton = container.querySelector('.w-1\\/4');
+      expect(timeSkeleton).toBeInTheDocument();
+      expect(timeSkeleton).toHaveClass('h-3');
+    });
+  });
+});

--- a/apps/web/src/domains/boards/components/__tests__/RecentAccessBadge.test.tsx
+++ b/apps/web/src/domains/boards/components/__tests__/RecentAccessBadge.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RecentAccessBadge } from '../RecentAccessBadge';
+
+describe('RecentAccessBadge', () => {
+  describe('렌더링', () => {
+    it('"최근 접속" 텍스트가 표시된다', () => {
+      // When
+      render(<RecentAccessBadge />);
+
+      // Then
+      expect(screen.getByText('최근 접속')).toBeInTheDocument();
+    });
+
+    it('span 요소로 렌더링된다', () => {
+      // When
+      render(<RecentAccessBadge />);
+
+      // Then
+      const badge = screen.getByText('최근 접속');
+      expect(badge.tagName).toBe('SPAN');
+    });
+  });
+
+  describe('스타일', () => {
+    it('기본 스타일 클래스가 적용된다', () => {
+      // When
+      render(<RecentAccessBadge />);
+
+      // Then
+      const badge = screen.getByText('최근 접속');
+      expect(badge).toHaveClass('inline-flex');
+      expect(badge).toHaveClass('rounded-full');
+      expect(badge).toHaveClass('text-xs');
+      expect(badge).toHaveClass('font-medium');
+    });
+
+    it('파란색 테마 클래스가 적용된다', () => {
+      // When
+      render(<RecentAccessBadge />);
+
+      // Then
+      const badge = screen.getByText('최근 접속');
+      expect(badge).toHaveClass('bg-blue-100');
+      expect(badge).toHaveClass('text-blue-700');
+    });
+
+    it('className prop으로 추가 스타일을 적용할 수 있다', () => {
+      // Given
+      const customClass = 'custom-test-class';
+
+      // When
+      render(<RecentAccessBadge className={customClass} />);
+
+      // Then
+      const badge = screen.getByText('최근 접속');
+      expect(badge).toHaveClass(customClass);
+    });
+  });
+});

--- a/apps/web/src/domains/boards/components/__tests__/RecentAccessBadge.test.tsx
+++ b/apps/web/src/domains/boards/components/__tests__/RecentAccessBadge.test.tsx
@@ -30,7 +30,6 @@ describe('RecentAccessBadge', () => {
       // Then
       const badge = screen.getByText('최근 접속');
       expect(badge).toHaveClass('inline-flex');
-      expect(badge).toHaveClass('rounded-full');
       expect(badge).toHaveClass('text-xs');
       expect(badge).toHaveClass('font-medium');
     });
@@ -41,7 +40,6 @@ describe('RecentAccessBadge', () => {
 
       // Then
       const badge = screen.getByText('최근 접속');
-      expect(badge).toHaveClass('bg-blue-100');
       expect(badge).toHaveClass('text-blue-700');
     });
 

--- a/apps/web/src/domains/boards/utils/__tests__/formatRelativeTime.test.ts
+++ b/apps/web/src/domains/boards/utils/__tests__/formatRelativeTime.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { formatRelativeTime } from '../formatRelativeTime';
+
+describe('formatRelativeTime', () => {
+  const MINUTE_MS = 60 * 1000;
+  const HOUR_MS = 60 * MINUTE_MS;
+  const DAY_MS = 24 * HOUR_MS;
+  const WEEK_MS = 7 * DAY_MS;
+  const MONTH_MS = 30 * DAY_MS;
+
+  const BASE_TIME = new Date('2025-01-07T12:00:00.000Z');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIME);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('미래 시간', () => {
+    it('미래 시간이 주어지면 "방금 전"을 반환한다', () => {
+      // Given
+      const futureDate = new Date(BASE_TIME.getTime() + HOUR_MS).toISOString();
+
+      // When
+      const result = formatRelativeTime(futureDate);
+
+      // Then
+      expect(result).toBe('방금 전');
+    });
+  });
+
+  describe('1분 미만', () => {
+    it('0초 전이면 "방금 전"을 반환한다', () => {
+      // Given
+      const now = BASE_TIME.toISOString();
+
+      // When
+      const result = formatRelativeTime(now);
+
+      // Then
+      expect(result).toBe('방금 전');
+    });
+
+    it('30초 전이면 "방금 전"을 반환한다', () => {
+      // Given
+      const thirtySecondsAgo = new Date(
+        BASE_TIME.getTime() - 30 * 1000,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(thirtySecondsAgo);
+
+      // Then
+      expect(result).toBe('방금 전');
+    });
+
+    it('59초 전이면 "방금 전"을 반환한다', () => {
+      // Given
+      const fiftyNineSecondsAgo = new Date(
+        BASE_TIME.getTime() - 59 * 1000,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(fiftyNineSecondsAgo);
+
+      // Then
+      expect(result).toBe('방금 전');
+    });
+  });
+
+  describe('분 단위 (1분 ~ 1시간 미만)', () => {
+    it('1분 전이면 "1분 전"을 반환한다', () => {
+      // Given
+      const oneMinuteAgo = new Date(
+        BASE_TIME.getTime() - MINUTE_MS,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(oneMinuteAgo);
+
+      // Then
+      expect(result).toBe('1분 전');
+    });
+
+    it('30분 전이면 "30분 전"을 반환한다', () => {
+      // Given
+      const thirtyMinutesAgo = new Date(
+        BASE_TIME.getTime() - 30 * MINUTE_MS,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(thirtyMinutesAgo);
+
+      // Then
+      expect(result).toBe('30분 전');
+    });
+
+    it('59분 전이면 "59분 전"을 반환한다', () => {
+      // Given
+      const fiftyNineMinutesAgo = new Date(
+        BASE_TIME.getTime() - 59 * MINUTE_MS,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(fiftyNineMinutesAgo);
+
+      // Then
+      expect(result).toBe('59분 전');
+    });
+  });
+
+  describe('시간 단위 (1시간 ~ 1일 미만)', () => {
+    it('1시간 전이면 "1시간 전"을 반환한다', () => {
+      // Given
+      const oneHourAgo = new Date(BASE_TIME.getTime() - HOUR_MS).toISOString();
+
+      // When
+      const result = formatRelativeTime(oneHourAgo);
+
+      // Then
+      expect(result).toBe('1시간 전');
+    });
+
+    it('3시간 전이면 "3시간 전"을 반환한다', () => {
+      // Given
+      const threeHoursAgo = new Date(
+        BASE_TIME.getTime() - 3 * HOUR_MS,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(threeHoursAgo);
+
+      // Then
+      expect(result).toBe('3시간 전');
+    });
+
+    it('23시간 전이면 "23시간 전"을 반환한다', () => {
+      // Given
+      const twentyThreeHoursAgo = new Date(
+        BASE_TIME.getTime() - 23 * HOUR_MS,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(twentyThreeHoursAgo);
+
+      // Then
+      expect(result).toBe('23시간 전');
+    });
+  });
+
+  describe('일 단위 (1일 ~ 1주 미만)', () => {
+    it('1일 전이면 "1일 전"을 반환한다', () => {
+      // Given
+      const oneDayAgo = new Date(BASE_TIME.getTime() - DAY_MS).toISOString();
+
+      // When
+      const result = formatRelativeTime(oneDayAgo);
+
+      // Then
+      expect(result).toBe('1일 전');
+    });
+
+    it('2일 전이면 "2일 전"을 반환한다', () => {
+      // Given
+      const twoDaysAgo = new Date(
+        BASE_TIME.getTime() - 2 * DAY_MS,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(twoDaysAgo);
+
+      // Then
+      expect(result).toBe('2일 전');
+    });
+
+    it('6일 전이면 "6일 전"을 반환한다', () => {
+      // Given
+      const sixDaysAgo = new Date(
+        BASE_TIME.getTime() - 6 * DAY_MS,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(sixDaysAgo);
+
+      // Then
+      expect(result).toBe('6일 전');
+    });
+  });
+
+  describe('주 단위 (1주 ~ 1개월 미만)', () => {
+    it('1주 전이면 "1주 전"을 반환한다', () => {
+      // Given
+      const oneWeekAgo = new Date(BASE_TIME.getTime() - WEEK_MS).toISOString();
+
+      // When
+      const result = formatRelativeTime(oneWeekAgo);
+
+      // Then
+      expect(result).toBe('1주 전');
+    });
+
+    it('2주 전이면 "2주 전"을 반환한다', () => {
+      // Given
+      const twoWeeksAgo = new Date(
+        BASE_TIME.getTime() - 2 * WEEK_MS,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(twoWeeksAgo);
+
+      // Then
+      expect(result).toBe('2주 전');
+    });
+
+    it('3주 전이면 "3주 전"을 반환한다', () => {
+      // Given
+      const threeWeeksAgo = new Date(
+        BASE_TIME.getTime() - 3 * WEEK_MS,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(threeWeeksAgo);
+
+      // Then
+      expect(result).toBe('3주 전');
+    });
+  });
+
+  describe('월 단위 (1개월 ~ 1년 미만)', () => {
+    it('1개월 전이면 "1개월 전"을 반환한다', () => {
+      // Given
+      const oneMonthAgo = new Date(
+        BASE_TIME.getTime() - MONTH_MS,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(oneMonthAgo);
+
+      // Then
+      expect(result).toBe('1개월 전');
+    });
+
+    it('6개월 전이면 "6개월 전"을 반환한다', () => {
+      // Given
+      const sixMonthsAgo = new Date(
+        BASE_TIME.getTime() - 6 * MONTH_MS,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(sixMonthsAgo);
+
+      // Then
+      expect(result).toBe('6개월 전');
+    });
+
+    it('11개월 전이면 "11개월 전"을 반환한다', () => {
+      // Given
+      const elevenMonthsAgo = new Date(
+        BASE_TIME.getTime() - 11 * MONTH_MS,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(elevenMonthsAgo);
+
+      // Then
+      expect(result).toBe('11개월 전');
+    });
+  });
+
+  describe('년 단위 (1년 이상)', () => {
+    it('1년 전이면 "1년 전"을 반환한다', () => {
+      // Given
+      const oneYearAgo = new Date(
+        BASE_TIME.getTime() - 12 * MONTH_MS,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(oneYearAgo);
+
+      // Then
+      expect(result).toBe('1년 전');
+    });
+
+    it('2년 전이면 "2년 전"을 반환한다', () => {
+      // Given
+      const twoYearsAgo = new Date(
+        BASE_TIME.getTime() - 24 * MONTH_MS,
+      ).toISOString();
+
+      // When
+      const result = formatRelativeTime(twoYearsAgo);
+
+      // Then
+      expect(result).toBe('2년 전');
+    });
+  });
+});

--- a/apps/web/src/domains/boards/utils/__tests__/isRecentlyAccessed.test.ts
+++ b/apps/web/src/domains/boards/utils/__tests__/isRecentlyAccessed.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isRecentlyAccessed } from '../isRecentlyAccessed';
+
+describe('isRecentlyAccessed', () => {
+  const DAY_MS = 1000 * 60 * 60 * 24;
+  const BASE_TIME = new Date('2025-01-07T12:00:00.000Z');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIME);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('null 또는 undefined 입력', () => {
+    it('lastAccessedAt이 null이면 false를 반환한다', () => {
+      // Given
+      const lastAccessedAt = null;
+
+      // When
+      const result = isRecentlyAccessed(lastAccessedAt);
+
+      // Then
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('최근 7일 이내 접속', () => {
+    it('방금 접속했으면 true를 반환한다', () => {
+      // Given
+      const lastAccessedAt = BASE_TIME.toISOString();
+
+      // When
+      const result = isRecentlyAccessed(lastAccessedAt);
+
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it('1일 전에 접속했으면 true를 반환한다', () => {
+      // Given
+      const oneDayAgo = new Date(BASE_TIME.getTime() - DAY_MS).toISOString();
+
+      // When
+      const result = isRecentlyAccessed(oneDayAgo);
+
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it('3일 전에 접속했으면 true를 반환한다', () => {
+      // Given
+      const threeDaysAgo = new Date(
+        BASE_TIME.getTime() - 3 * DAY_MS,
+      ).toISOString();
+
+      // When
+      const result = isRecentlyAccessed(threeDaysAgo);
+
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it('7일 전에 접속했으면 true를 반환한다 (경계값)', () => {
+      // Given
+      const sevenDaysAgo = new Date(
+        BASE_TIME.getTime() - 7 * DAY_MS,
+      ).toISOString();
+
+      // When
+      const result = isRecentlyAccessed(sevenDaysAgo);
+
+      // Then
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('7일 초과 접속', () => {
+    it('8일 전에 접속했으면 false를 반환한다', () => {
+      // Given
+      const eightDaysAgo = new Date(
+        BASE_TIME.getTime() - 8 * DAY_MS,
+      ).toISOString();
+
+      // When
+      const result = isRecentlyAccessed(eightDaysAgo);
+
+      // Then
+      expect(result).toBe(false);
+    });
+
+    it('30일 전에 접속했으면 false를 반환한다', () => {
+      // Given
+      const thirtyDaysAgo = new Date(
+        BASE_TIME.getTime() - 30 * DAY_MS,
+      ).toISOString();
+
+      // When
+      const result = isRecentlyAccessed(thirtyDaysAgo);
+
+      // Then
+      expect(result).toBe(false);
+    });
+
+    it('1년 전에 접속했으면 false를 반환한다', () => {
+      // Given
+      const oneYearAgo = new Date(
+        BASE_TIME.getTime() - 365 * DAY_MS,
+      ).toISOString();
+
+      // When
+      const result = isRecentlyAccessed(oneYearAgo);
+
+      // Then
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/domains/boards/utils/formatRelativeTime.ts
+++ b/apps/web/src/domains/boards/utils/formatRelativeTime.ts
@@ -24,6 +24,11 @@ const TIME_UNITS: TimeUnit[] = [
  */
 export function formatRelativeTime(dateString: string): string {
   const date = new Date(dateString);
+
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
 

--- a/apps/web/src/domains/boards/utils/formatRelativeTime.ts
+++ b/apps/web/src/domains/boards/utils/formatRelativeTime.ts
@@ -1,0 +1,52 @@
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+const MONTH_MS = 30 * DAY_MS;
+
+interface TimeUnit {
+  threshold: number;
+  unit: string;
+  divisor: number;
+}
+
+const TIME_UNITS: TimeUnit[] = [
+  { threshold: MINUTE_MS, unit: '방금 전', divisor: 0 },
+  { threshold: HOUR_MS, unit: '분 전', divisor: MINUTE_MS },
+  { threshold: DAY_MS, unit: '시간 전', divisor: HOUR_MS },
+  { threshold: WEEK_MS, unit: '일 전', divisor: DAY_MS },
+  { threshold: MONTH_MS, unit: '주 전', divisor: WEEK_MS },
+];
+
+/**
+ * 주어진 날짜를 현재 시간 기준 상대적 시간 문자열로 변환합니다.
+ * 예: "방금 전", "5분 전", "3시간 전", "2일 전", "1주 전"
+ */
+export function formatRelativeTime(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+
+  if (diffMs < 0) {
+    return '방금 전';
+  }
+
+  const matchedUnit = TIME_UNITS.find(({ threshold }) => diffMs < threshold);
+
+  if (matchedUnit) {
+    const { unit, divisor } = matchedUnit;
+    if (divisor === 0) {
+      return unit;
+    }
+    const value = Math.floor(diffMs / divisor);
+    return `${value}${unit}`;
+  }
+
+  const months = Math.floor(diffMs / MONTH_MS);
+  if (months < 12) {
+    return `${months}개월 전`;
+  }
+
+  const years = Math.floor(months / 12);
+  return `${years}년 전`;
+}

--- a/apps/web/src/domains/boards/utils/isRecentlyAccessed.ts
+++ b/apps/web/src/domains/boards/utils/isRecentlyAccessed.ts
@@ -10,6 +10,10 @@ export function isRecentlyAccessed(lastAccessedAt: string | null): boolean {
   }
 
   const accessDate = new Date(lastAccessedAt);
+  if (Number.isNaN(accessDate.getTime())) {
+    return false;
+  }
+
   const now = new Date();
   const diffInDays = (now.getTime() - accessDate.getTime()) / DAY_MS;
 

--- a/apps/web/src/domains/boards/utils/isRecentlyAccessed.ts
+++ b/apps/web/src/domains/boards/utils/isRecentlyAccessed.ts
@@ -1,0 +1,17 @@
+const RECENT_ACCESS_THRESHOLD_DAYS = 7;
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+/**
+ * 주어진 마지막 접속 시간이 최근 7일 이내인지 확인합니다.
+ */
+export function isRecentlyAccessed(lastAccessedAt: string | null): boolean {
+  if (!lastAccessedAt) {
+    return false;
+  }
+
+  const accessDate = new Date(lastAccessedAt);
+  const now = new Date();
+  const diffInDays = (now.getTime() - accessDate.getTime()) / DAY_MS;
+
+  return diffInDays <= RECENT_ACCESS_THRESHOLD_DAYS;
+}

--- a/apps/web/test/setup.ts
+++ b/apps/web/test/setup.ts
@@ -1,6 +1,17 @@
+/* eslint-disable class-methods-use-this */
 import '@testing-library/jest-dom';
 import { cleanup } from '@testing-library/react';
 import { afterEach, beforeEach } from 'vitest';
+
+// ResizeObserver 모킹 (headlessui/react 컴포넌트에서 사용)
+class ResizeObserverMock {
+  observe() {}
+
+  unobserve() {}
+
+  disconnect() {}
+}
+window.ResizeObserver = ResizeObserverMock;
 
 // localStorage 모킹
 const localStorageMock = (() => {

--- a/apps/web/vitest.shims.d.ts
+++ b/apps/web/vitest.shims.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="@vitest/browser-playwright" />
+/// <reference types="@testing-library/jest-dom" />


### PR DESCRIPTION
<div align="center"><img src="https://github.com/user-attachments/assets/065c23b0-6336-4dae-a2e6-3fd9db732d1a" width="320px" /></div>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a richer boards UI and routing with supporting utilities and tests.
> 
> - Adds `BoardCard` (keyboard-accessible) with background preview, relative `updatedAt` display, and context menu (`수정/삭제`), plus `RecentAccessBadge`
> - Integrates `BoardCard` into `BoardGrid`; adds loading skeletons, improved error/empty states, and keeps infinite scroll via intersection observer
> - Introduces `/boards/:boardId` route and simple `BoardDetailPage`
> - Adds utils: `formatRelativeTime` and `isRecentlyAccessed`
> - Extensive tests for components and utils; updates test setup (ResizeObserver mock, jest-dom types)
> - Updates `.gitignore` to include `docs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2900874e1b10b03c7d2e1b9b20931a1d3aef05e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * /boards/:boardId 상세 페이지 추가
  * 보드 카드(타이틀·배경·키보드 접근성), 편집/삭제 드롭다운 및 스켈레톤 로딩 추가
  * 빈 상태와 오류 메시지 표시 개선, 클릭/키보드로 보드 이동 지원

* **유틸**
  * 한국어 상대 시간 포맷 함수 추가
  * 최근 접속 판정(7일 기준) 유틸 추가

* **테스트**
  * 보드 UI 및 유틸에 대한 광범위한 단위/통합 테스트 추가

* **잡일**
  * 테스트 환경 설정(ResizeObserver 모킹, 타입 선언) 및 .gitignore 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->