### PR TITLE
Feat/25 보드 생성 모달 구현

### DIFF
--- a/apps/web/src/domains/boards/CreateBoardButton.tsx
+++ b/apps/web/src/domains/boards/CreateBoardButton.tsx
@@ -1,11 +1,37 @@
-function CreateBoardButton() {
+import { useState, useCallback } from 'react';
+
+import { Button } from '@/components/ui/Button';
+import { CreateBoardModal } from '@/domains/boards/components/CreateBoardModal';
+
+interface CreateBoardButtonProps {
+  onSuccess?: (boardId: string) => void;
+}
+
+/**
+ * 새 보드 만들기 버튼 컴포넌트
+ * 클릭 시 보드 생성 모달을 엽니다.
+ */
+function CreateBoardButton({ onSuccess }: CreateBoardButtonProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleOpen = useCallback(() => {
+    setIsModalOpen(true);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsModalOpen(false);
+  }, []);
+
   return (
-    <button
-      className="rounded-md bg-slate-900 px-4 py-2 text-sm text-white hover:bg-slate-900/90 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/90"
-      type="button"
-    >
-      새 보드 만들기
-    </button>
+    <>
+      <Button onClick={handleOpen}>새 보드 만들기</Button>
+      <CreateBoardModal
+        isOpen={isModalOpen}
+        onClose={handleClose}
+        onSuccess={onSuccess}
+      />
+    </>
   );
 }
+
 export default CreateBoardButton;

--- a/apps/web/src/domains/boards/components/BoardPreview.tsx
+++ b/apps/web/src/domains/boards/components/BoardPreview.tsx
@@ -1,0 +1,33 @@
+import { cn } from '@/lib/utils/cn';
+
+const PREVIEW_HEIGHT_PX = 80;
+
+interface BoardPreviewProps {
+  /** 배경색 HEX 값 */
+  backgroundColor: string;
+  /** 추가 CSS 클래스 */
+  className?: string;
+}
+
+/**
+ * 보드 배경색 미리보기 컴포넌트
+ * 선택된 배경색을 시각적으로 미리 보여줍니다.
+ */
+export function BoardPreview({
+  backgroundColor,
+  className,
+}: BoardPreviewProps) {
+  return (
+    <div
+      className={cn(
+        'w-full rounded-lg transition-colors duration-200',
+        className,
+      )}
+      style={{
+        backgroundColor,
+        height: `${PREVIEW_HEIGHT_PX}px`,
+      }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/apps/web/src/domains/boards/components/ColorPicker.tsx
+++ b/apps/web/src/domains/boards/components/ColorPicker.tsx
@@ -1,0 +1,72 @@
+import { Check } from 'lucide-react';
+
+import { cn } from '@/lib/utils/cn';
+import {
+  BOARD_COLOR_PRESETS,
+  type BoardColorPreset,
+} from '@/domains/boards/constants/colors';
+
+const COLOR_BUTTON_SIZE_PX = 32;
+
+interface ColorPickerProps {
+  /** 선택된 색상 값 */
+  selectedColor: string;
+  /** 색상 선택 콜백 */
+  onSelect: (color: string) => void;
+  /** 색상 프리셋 (기본값: BOARD_COLOR_PRESETS) */
+  colors?: readonly BoardColorPreset[];
+}
+
+/**
+ * 색상 선택기 컴포넌트
+ * 보드 배경색을 선택할 수 있는 라디오 버튼 그룹
+ */
+export function ColorPicker({
+  selectedColor,
+  onSelect,
+  colors = BOARD_COLOR_PRESETS,
+}: ColorPickerProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="배경색 선택"
+      className="flex flex-wrap gap-3"
+    >
+      {colors.map((color) => {
+        const isSelected = selectedColor === color.value;
+
+        return (
+          <button
+            key={color.id}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            aria-label={color.label}
+            onClick={() => onSelect(color.value)}
+            className={cn(
+              'rounded-full transition-all duration-150',
+              'flex items-center justify-center',
+              'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500',
+              'hover:ring-2 hover:ring-offset-2 hover:ring-gray-300',
+              isSelected && 'ring-2 ring-offset-2 ring-blue-500',
+            )}
+            style={{
+              backgroundColor: color.value,
+              width: `${COLOR_BUTTON_SIZE_PX}px`,
+              height: `${COLOR_BUTTON_SIZE_PX}px`,
+            }}
+          >
+            {isSelected && (
+              <Check
+                className="text-white drop-shadow-sm"
+                size={18}
+                strokeWidth={3}
+                aria-hidden="true"
+              />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/domains/boards/components/CreateBoardModal.tsx
+++ b/apps/web/src/domains/boards/components/CreateBoardModal.tsx
@@ -45,6 +45,12 @@ export function CreateBoardModal({
   const navigate = useNavigate();
   const titleInputRef = useRef<HTMLInputElement>(null);
   const createBoardMutation = useCreateBoard();
+  const {
+    reset: resetMutation,
+    mutateAsync: mutateAsyncMutation,
+    isPending: isPendingMutation,
+    isError: isErrorMutation,
+  } = createBoardMutation;
 
   const {
     register,
@@ -73,12 +79,14 @@ export function CreateBoardModal({
         title: '',
         backgroundColor: DEFAULT_BOARD_COLOR,
       });
+      // 모달 생성 실패 후 에러 상태 초기화 (API 호출 후 에러 상태 초기화)
+      resetMutation();
       // 다음 틱에서 포커스 (Dialog 애니메이션 완료 후)
       setTimeout(() => {
         titleInputRef.current?.focus();
       }, 0);
     }
-  }, [isOpen, reset]);
+  }, [isOpen, reset, resetMutation]);
 
   const handleColorSelect = (color: string) => {
     setValue('backgroundColor', color, { shouldValidate: true });
@@ -86,7 +94,7 @@ export function CreateBoardModal({
 
   const onSubmit = async (data: CreateBoardFormData) => {
     try {
-      const newBoard = await createBoardMutation.mutateAsync(data);
+      const newBoard = await mutateAsyncMutation(data);
       onClose();
       onSuccess?.(newBoard.id);
       navigate(`/boards/${newBoard.id}`);
@@ -96,7 +104,7 @@ export function CreateBoardModal({
   };
 
   const handleClose = () => {
-    if (!createBoardMutation.isPending) {
+    if (!isPendingMutation) {
       onClose();
     }
   };
@@ -132,7 +140,7 @@ export function CreateBoardModal({
             <button
               type="button"
               onClick={handleClose}
-              disabled={createBoardMutation.isPending}
+              disabled={isPendingMutation}
               className={cn(
                 'rounded-lg p-1.5 text-gray-400 transition-colors',
                 'hover:bg-gray-100 hover:text-gray-600',
@@ -214,7 +222,7 @@ export function CreateBoardModal({
             </div>
 
             {/* 에러 메시지 */}
-            {createBoardMutation.isError && (
+            {isErrorMutation && (
               <div
                 role="alert"
                 className="mb-4 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 text-sm text-red-600 dark:text-red-400"
@@ -229,21 +237,21 @@ export function CreateBoardModal({
                 type="button"
                 variant="secondary"
                 onClick={handleClose}
-                disabled={createBoardMutation.isPending}
+                disabled={isPendingMutation}
                 className="flex-1"
               >
                 취소
               </Button>
               <Button
                 type="submit"
-                disabled={!isValid || createBoardMutation.isPending}
+                disabled={!isValid || isPendingMutation}
                 className={cn(
                   'flex-1 bg-blue-600 text-white',
                   'hover:bg-blue-700',
                   'disabled:opacity-50 disabled:cursor-not-allowed',
                 )}
               >
-                {createBoardMutation.isPending ? (
+                {isPendingMutation ? (
                   <span className="flex items-center gap-2">
                     <Loader2 className="animate-spin" size={16} />
                     생성 중...

--- a/apps/web/src/domains/boards/components/CreateBoardModal.tsx
+++ b/apps/web/src/domains/boards/components/CreateBoardModal.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useNavigate } from 'react-router-dom';
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  DialogBackdrop,
+} from '@headlessui/react';
+import { X, Loader2 } from 'lucide-react';
+
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { BoardPreview } from '@/domains/boards/components/BoardPreview';
+import { ColorPicker } from '@/domains/boards/components/ColorPicker';
+import { DEFAULT_BOARD_COLOR } from '@/domains/boards/constants/colors';
+import {
+  createBoardSchema,
+  type CreateBoardFormData,
+} from '@/domains/boards/schemas/createBoardSchema';
+import { useCreateBoard } from '@/domains/boards/hooks/useCreateBoard';
+
+const TITLE_MAX_LENGTH = 100;
+
+interface CreateBoardModalProps {
+  /** 모달 열림 상태 */
+  isOpen: boolean;
+  /** 모달 닫기 콜백 */
+  onClose: () => void;
+  /** 생성 성공 콜백 (선택) */
+  onSuccess?: (boardId: string) => void;
+}
+
+/**
+ * 보드 생성 모달 컴포넌트
+ * 보드 제목 입력과 배경색 선택 기능을 제공합니다.
+ */
+export function CreateBoardModal({
+  isOpen,
+  onClose,
+  onSuccess,
+}: CreateBoardModalProps) {
+  const navigate = useNavigate();
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  const createBoardMutation = useCreateBoard();
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    reset,
+    formState: { errors, isValid },
+  } = useForm<CreateBoardFormData>({
+    resolver: zodResolver(createBoardSchema),
+    defaultValues: {
+      title: '',
+      backgroundColor: DEFAULT_BOARD_COLOR,
+    },
+    mode: 'onChange',
+  });
+
+  const title = watch('title');
+  const backgroundColor = watch('backgroundColor');
+  const titleLength = title.length;
+
+  // 모달 열릴 때 폼 초기화 및 포커스
+  useEffect(() => {
+    if (isOpen) {
+      reset({
+        title: '',
+        backgroundColor: DEFAULT_BOARD_COLOR,
+      });
+      // 다음 틱에서 포커스 (Dialog 애니메이션 완료 후)
+      setTimeout(() => {
+        titleInputRef.current?.focus();
+      }, 0);
+    }
+  }, [isOpen, reset]);
+
+  const handleColorSelect = (color: string) => {
+    setValue('backgroundColor', color, { shouldValidate: true });
+  };
+
+  const onSubmit = async (data: CreateBoardFormData) => {
+    try {
+      const newBoard = await createBoardMutation.mutateAsync(data);
+      onClose();
+      onSuccess?.(newBoard.id);
+      navigate(`/boards/${newBoard.id}`);
+    } catch {
+      // 에러는 mutation의 error 상태로 처리
+    }
+  };
+
+  const handleClose = () => {
+    if (!createBoardMutation.isPending) {
+      onClose();
+    }
+  };
+
+  const { ref: registerRef, ...titleRegisterProps } = register('title');
+
+  return (
+    <Dialog open={isOpen} onClose={handleClose} className="relative z-50">
+      <DialogBackdrop
+        transition
+        className={cn(
+          'fixed inset-0 bg-black/50 backdrop-blur-sm',
+          'transition-opacity duration-200',
+          'data-closed:opacity-0',
+        )}
+      />
+
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <DialogPanel
+          transition
+          className={cn(
+            'w-full max-w-md rounded-xl bg-white p-6 shadow-xl',
+            'dark:bg-slate-900',
+            'transition-all duration-200',
+            'data-closed:scale-95 data-closed:opacity-0',
+          )}
+        >
+          {/* 헤더 */}
+          <div className="flex items-center justify-between mb-6">
+            <DialogTitle className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              새 보드 만들기
+            </DialogTitle>
+            <button
+              type="button"
+              onClick={handleClose}
+              disabled={createBoardMutation.isPending}
+              className={cn(
+                'rounded-lg p-1.5 text-gray-400 transition-colors',
+                'hover:bg-gray-100 hover:text-gray-600',
+                'dark:hover:bg-slate-800 dark:hover:text-gray-300',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
+                'disabled:opacity-50 disabled:cursor-not-allowed',
+              )}
+              aria-label="닫기"
+            >
+              <X size={20} />
+            </button>
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)}>
+            {/* 미리보기 */}
+            <BoardPreview backgroundColor={backgroundColor} className="mb-6" />
+
+            {/* 제목 입력 */}
+            <div className="mb-6">
+              <label
+                htmlFor="board-title"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+              >
+                보드 제목 <span className="text-red-500">*</span>
+              </label>
+              <Input
+                id="board-title"
+                type="text"
+                placeholder="프로젝트 이름을 입력하세요"
+                aria-required="true"
+                aria-invalid={!!errors.title}
+                aria-describedby={errors.title ? 'title-error' : undefined}
+                {...titleRegisterProps}
+                ref={(e) => {
+                  registerRef(e);
+                  (
+                    titleInputRef as React.MutableRefObject<HTMLInputElement | null>
+                  ).current = e;
+                }}
+                className={cn(
+                  'h-11',
+                  errors.title && 'border-red-500 focus-visible:ring-red-500',
+                )}
+              />
+              <div className="flex justify-between mt-1.5">
+                {errors.title ? (
+                  <p
+                    id="title-error"
+                    role="alert"
+                    className="text-sm text-red-500"
+                  >
+                    {errors.title.message}
+                  </p>
+                ) : (
+                  <span />
+                )}
+                <span
+                  className={cn(
+                    'text-sm',
+                    titleLength > TITLE_MAX_LENGTH
+                      ? 'text-red-500'
+                      : 'text-gray-400',
+                  )}
+                >
+                  {titleLength} / {TITLE_MAX_LENGTH}
+                </span>
+              </div>
+            </div>
+
+            {/* 배경색 선택 */}
+            <div className="mb-6">
+              <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                배경색
+              </span>
+              <ColorPicker
+                selectedColor={backgroundColor}
+                onSelect={handleColorSelect}
+              />
+            </div>
+
+            {/* 에러 메시지 */}
+            {createBoardMutation.isError && (
+              <div
+                role="alert"
+                className="mb-4 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 text-sm text-red-600 dark:text-red-400"
+              >
+                보드 생성에 실패했습니다. 다시 시도해주세요.
+              </div>
+            )}
+
+            {/* 버튼 */}
+            <div className="flex gap-3">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={handleClose}
+                disabled={createBoardMutation.isPending}
+                className="flex-1"
+              >
+                취소
+              </Button>
+              <Button
+                type="submit"
+                disabled={!isValid || createBoardMutation.isPending}
+                className={cn(
+                  'flex-1 bg-blue-600 text-white',
+                  'hover:bg-blue-700',
+                  'disabled:opacity-50 disabled:cursor-not-allowed',
+                )}
+              >
+                {createBoardMutation.isPending ? (
+                  <span className="flex items-center gap-2">
+                    <Loader2 className="animate-spin" size={16} />
+                    생성 중...
+                  </span>
+                ) : (
+                  '만들기'
+                )}
+              </Button>
+            </div>
+          </form>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/domains/boards/components/__tests__/BoardPreview.test.tsx
+++ b/apps/web/src/domains/boards/components/__tests__/BoardPreview.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BoardPreview } from '../BoardPreview';
+
+describe('BoardPreview', () => {
+  describe('렌더링', () => {
+    it('배경색이 적용된다', () => {
+      // Given
+      const backgroundColor = '#0079BF';
+
+      // When
+      const { container } = render(
+        <BoardPreview backgroundColor={backgroundColor} />,
+      );
+
+      // Then
+      const previewDiv = container.firstChild as HTMLElement;
+      expect(previewDiv).toHaveStyle({ backgroundColor });
+    });
+
+    it('높이가 80px로 설정된다', () => {
+      // Given
+      const backgroundColor = '#0079BF';
+
+      // When
+      const { container } = render(
+        <BoardPreview backgroundColor={backgroundColor} />,
+      );
+
+      // Then
+      const previewDiv = container.firstChild as HTMLElement;
+      expect(previewDiv).toHaveStyle({ height: '80px' });
+    });
+
+    it('추가 className이 적용된다', () => {
+      // Given
+      const backgroundColor = '#0079BF';
+      const className = 'custom-class';
+
+      // When
+      const { container } = render(
+        <BoardPreview
+          backgroundColor={backgroundColor}
+          className={className}
+        />,
+      );
+
+      // Then
+      const previewDiv = container.firstChild as HTMLElement;
+      expect(previewDiv).toHaveClass('custom-class');
+    });
+  });
+
+  describe('접근성', () => {
+    it('aria-hidden="true"가 설정된다', () => {
+      // Given
+      const backgroundColor = '#0079BF';
+
+      // When
+      const { container } = render(
+        <BoardPreview backgroundColor={backgroundColor} />,
+      );
+
+      // Then
+      const previewDiv = container.firstChild as HTMLElement;
+      expect(previewDiv).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('스크린 리더에서 숨겨진다', () => {
+      // Given
+      const backgroundColor = '#0079BF';
+
+      // When
+      render(<BoardPreview backgroundColor={backgroundColor} />);
+
+      // Then
+      // aria-hidden 요소는 접근성 트리에서 제외됨
+      expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('다양한 색상', () => {
+    const testColors = [
+      { id: 'blue', value: '#0079BF' },
+      { id: 'orange', value: '#D29034' },
+      { id: 'green', value: '#519839' },
+      { id: 'red', value: '#B04632' },
+      { id: 'purple', value: '#89609E' },
+      { id: 'pink', value: '#CD5A91' },
+    ];
+
+    it.each(testColors)('$id 색상($value)이 올바르게 적용된다', ({ value }) => {
+      // When
+      const { container } = render(<BoardPreview backgroundColor={value} />);
+
+      // Then
+      const previewDiv = container.firstChild as HTMLElement;
+      expect(previewDiv).toHaveStyle({ backgroundColor: value });
+    });
+  });
+});

--- a/apps/web/src/domains/boards/components/__tests__/ColorPicker.test.tsx
+++ b/apps/web/src/domains/boards/components/__tests__/ColorPicker.test.tsx
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ColorPicker } from '@/domains/boards/components/ColorPicker';
+import { BOARD_COLOR_PRESETS } from '@/domains/boards/constants/colors';
+
+describe('ColorPicker', () => {
+  const createDefaultProps = () => ({
+    selectedColor: BOARD_COLOR_PRESETS[0].value,
+    onSelect: vi.fn(),
+  });
+
+  describe('렌더링', () => {
+    it('모든 색상 프리셋이 렌더링된다', () => {
+      // Given
+      const props = createDefaultProps();
+
+      // When
+      render(<ColorPicker {...props} />);
+
+      // Then
+      BOARD_COLOR_PRESETS.forEach((color) => {
+        expect(
+          screen.getByRole('radio', { name: color.label }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('6개의 색상 버튼이 표시된다', () => {
+      // Given
+      const props = createDefaultProps();
+
+      // When
+      render(<ColorPicker {...props} />);
+
+      // Then
+      const radioButtons = screen.getAllByRole('radio');
+      expect(radioButtons).toHaveLength(6);
+    });
+
+    it('각 버튼에 올바른 배경색이 적용된다', () => {
+      // Given
+      const props = createDefaultProps();
+
+      // When
+      render(<ColorPicker {...props} />);
+
+      // Then
+      BOARD_COLOR_PRESETS.forEach((color) => {
+        const button = screen.getByRole('radio', { name: color.label });
+        expect(button).toHaveStyle({ backgroundColor: color.value });
+      });
+    });
+
+    it('버튼 크기가 32x32px이다', () => {
+      // Given
+      const props = createDefaultProps();
+
+      // When
+      render(<ColorPicker {...props} />);
+
+      // Then
+      const firstButton = screen.getByRole('radio', {
+        name: BOARD_COLOR_PRESETS[0].label,
+      });
+      expect(firstButton).toHaveStyle({ width: '32px', height: '32px' });
+    });
+  });
+
+  describe('선택 상태', () => {
+    it('선택된 색상에 aria-checked="true"가 설정된다', () => {
+      // Given
+      const selectedColor = BOARD_COLOR_PRESETS[2].value; // 초록
+      const props = { ...createDefaultProps(), selectedColor };
+
+      // When
+      render(<ColorPicker {...props} />);
+
+      // Then
+      const selectedButton = screen.getByRole('radio', { name: '초록' });
+      expect(selectedButton).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('선택되지 않은 색상에 aria-checked="false"가 설정된다', () => {
+      // Given
+      const selectedColor = BOARD_COLOR_PRESETS[0].value; // 파랑
+      const props = { ...createDefaultProps(), selectedColor };
+
+      // When
+      render(<ColorPicker {...props} />);
+
+      // Then
+      const unselectedButton = screen.getByRole('radio', { name: '초록' });
+      expect(unselectedButton).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('선택된 색상에만 체크 아이콘이 표시된다', () => {
+      // Given
+      const selectedColor = BOARD_COLOR_PRESETS[1].value; // 주황
+      const props = { ...createDefaultProps(), selectedColor };
+
+      // When
+      render(<ColorPicker {...props} />);
+
+      // Then
+      const selectedButton = screen.getByRole('radio', { name: '주황' });
+      const checkIcon = selectedButton.querySelector('svg');
+      expect(checkIcon).toBeInTheDocument();
+
+      // 다른 버튼에는 체크 아이콘이 없어야 함
+      const unselectedButton = screen.getByRole('radio', { name: '파랑' });
+      const noCheckIcon = unselectedButton.querySelector('svg');
+      expect(noCheckIcon).not.toBeInTheDocument();
+    });
+  });
+
+  describe('클릭 동작', () => {
+    it('색상 버튼 클릭 시 onSelect가 해당 색상 값과 함께 호출된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      render(<ColorPicker {...props} />);
+
+      // When
+      await user.click(screen.getByRole('radio', { name: '초록' }));
+
+      // Then
+      expect(props.onSelect).toHaveBeenCalledWith(BOARD_COLOR_PRESETS[2].value);
+    });
+
+    it('다른 색상을 클릭할 때마다 onSelect가 호출된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      render(<ColorPicker {...props} />);
+
+      // When
+      await user.click(screen.getByRole('radio', { name: '빨강' }));
+      await user.click(screen.getByRole('radio', { name: '보라' }));
+      await user.click(screen.getByRole('radio', { name: '분홍' }));
+
+      // Then
+      expect(props.onSelect).toHaveBeenCalledTimes(3);
+      expect(props.onSelect).toHaveBeenNthCalledWith(
+        1,
+        BOARD_COLOR_PRESETS[3].value,
+      ); // 빨강
+      expect(props.onSelect).toHaveBeenNthCalledWith(
+        2,
+        BOARD_COLOR_PRESETS[4].value,
+      ); // 보라
+      expect(props.onSelect).toHaveBeenNthCalledWith(
+        3,
+        BOARD_COLOR_PRESETS[5].value,
+      ); // 분홍
+    });
+  });
+
+  describe('접근성', () => {
+    it('radiogroup role이 설정된다', () => {
+      // Given
+      const props = createDefaultProps();
+
+      // When
+      render(<ColorPicker {...props} />);
+
+      // Then
+      expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+    });
+
+    it('radiogroup에 aria-label이 설정된다', () => {
+      // Given
+      const props = createDefaultProps();
+
+      // When
+      render(<ColorPicker {...props} />);
+
+      // Then
+      expect(screen.getByRole('radiogroup')).toHaveAttribute(
+        'aria-label',
+        '배경색 선택',
+      );
+    });
+
+    it('각 버튼에 radio role이 설정된다', () => {
+      // Given
+      const props = createDefaultProps();
+
+      // When
+      render(<ColorPicker {...props} />);
+
+      // Then
+      const radioButtons = screen.getAllByRole('radio');
+      expect(radioButtons).toHaveLength(BOARD_COLOR_PRESETS.length);
+    });
+
+    it('키보드로 색상을 선택할 수 있다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      render(<ColorPicker {...props} />);
+
+      // When
+      const firstButton = screen.getByRole('radio', { name: '파랑' });
+      firstButton.focus();
+      await user.keyboard('{Tab}');
+      await user.keyboard('{Enter}');
+
+      // Then
+      expect(props.onSelect).toHaveBeenCalled();
+    });
+  });
+
+  describe('커스텀 색상 프리셋', () => {
+    it('커스텀 색상 프리셋을 전달할 수 있다', () => {
+      // Given
+      const customColors = [
+        { id: 'custom1', value: '#111111', label: '커스텀1' },
+        { id: 'custom2', value: '#222222', label: '커스텀2' },
+      ] as const;
+      const props = {
+        selectedColor: '#111111',
+        onSelect: vi.fn(),
+        colors: customColors,
+      };
+
+      // When
+      render(<ColorPicker {...props} />);
+
+      // Then
+      expect(
+        screen.getByRole('radio', { name: '커스텀1' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('radio', { name: '커스텀2' }),
+      ).toBeInTheDocument();
+      expect(screen.getAllByRole('radio')).toHaveLength(2);
+    });
+  });
+});

--- a/apps/web/src/domains/boards/components/__tests__/CreateBoardModal.test.tsx
+++ b/apps/web/src/domains/boards/components/__tests__/CreateBoardModal.test.tsx
@@ -1,0 +1,730 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { CreateBoardModal } from '@/domains/boards/components/CreateBoardModal';
+import apiClient from '@/lib/api/api-client';
+import {
+  BOARD_COLOR_PRESETS,
+  DEFAULT_BOARD_COLOR,
+} from '@/domains/boards/constants/colors';
+
+// react-router-dom의 useNavigate 모킹
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// apiClient 모킹
+vi.mock('@/lib/api/api-client', () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+const mockApiClient = vi.mocked(apiClient);
+
+describe('CreateBoardModal', () => {
+  let queryClient: QueryClient;
+
+  const createWrapper = () => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    return function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>{children}</MemoryRouter>
+        </QueryClientProvider>
+      );
+    };
+  };
+
+  const createDefaultProps = () => ({
+    isOpen: true,
+    onClose: vi.fn(),
+    onSuccess: vi.fn(),
+  });
+
+  const mockBoardResponse = {
+    id: 'board-123',
+    title: '새 프로젝트',
+    backgroundColor: '#0079BF',
+    createdAt: '2025-01-07T12:00:00.000Z',
+    updatedAt: '2025-01-07T12:00:00.000Z',
+    lastAccessedAt: null,
+    listsCount: 0,
+    cardsCount: 0,
+    members: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+  });
+
+  describe('렌더링', () => {
+    it('모달이 열리면 "새 보드 만들기" 제목이 표시된다', () => {
+      // Given
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      // When
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // Then
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText('새 보드 만들기')).toBeInTheDocument();
+    });
+
+    it('isOpen이 false면 모달이 렌더링되지 않는다', () => {
+      // Given
+      const props = { ...createDefaultProps(), isOpen: false };
+      const Wrapper = createWrapper();
+
+      // When
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // Then
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('배경색 미리보기가 기본 색상으로 표시된다', async () => {
+      // Given
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      // When
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // Then - 미리보기는 높이 80px의 div 요소
+      await waitFor(() => {
+        const preview = document.querySelector('div[style*="height: 80px"]');
+        expect(preview).toBeInTheDocument();
+        // 기본 색상 #0079BF = rgb(0, 121, 191)
+        expect(preview).toHaveStyle({ backgroundColor: 'rgb(0, 121, 191)' });
+      });
+    });
+
+    it('6개의 색상 선택 버튼이 표시된다', () => {
+      // Given
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      // When
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // Then
+      const colorButtons = screen.getAllByRole('radio');
+      expect(colorButtons).toHaveLength(BOARD_COLOR_PRESETS.length);
+    });
+
+    it('취소 버튼과 만들기 버튼이 표시된다', () => {
+      // Given
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      // When
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // Then
+      expect(screen.getByRole('button', { name: '취소' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: '만들기' }),
+      ).toBeInTheDocument();
+    });
+
+    it('닫기 버튼이 표시된다', () => {
+      // Given
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      // When
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // Then
+      expect(screen.getByRole('button', { name: '닫기' })).toBeInTheDocument();
+    });
+  });
+
+  describe('제목 입력', () => {
+    it('제목 입력 필드가 표시된다', () => {
+      // Given
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      // When
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // Then
+      expect(screen.getByLabelText(/보드 제목/)).toBeInTheDocument();
+    });
+
+    it('제목을 입력할 수 있다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      const input = screen.getByLabelText(/보드 제목/);
+      await user.type(input, '새 프로젝트');
+
+      // Then
+      expect(input).toHaveValue('새 프로젝트');
+    });
+
+    it('글자 수 카운터가 표시된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      const input = screen.getByLabelText(/보드 제목/);
+      await user.type(input, '테스트');
+
+      // Then
+      expect(screen.getByText('3 / 100')).toBeInTheDocument();
+    });
+
+    it('제목이 비어있으면 만들기 버튼이 비활성화된다', () => {
+      // Given
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      // When
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // Then
+      const submitButton = screen.getByRole('button', { name: '만들기' });
+      expect(submitButton).toBeDisabled();
+    });
+
+    it('제목 입력 시 만들기 버튼이 활성화된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      const input = screen.getByLabelText(/보드 제목/);
+      await user.type(input, '새 프로젝트');
+
+      // Then
+      const submitButton = screen.getByRole('button', { name: '만들기' });
+      expect(submitButton).not.toBeDisabled();
+    });
+
+    it('100자 초과 입력 시 에러 메시지가 표시된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      const input = screen.getByLabelText(/보드 제목/);
+      await user.type(input, 'a'.repeat(101));
+
+      // Then
+      await waitFor(() => {
+        expect(
+          screen.getByText('보드 제목은 100자 이하로 입력해주세요.'),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('배경색 선택', () => {
+    it('색상 버튼 클릭 시 미리보기 색상이 변경된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      const greenColorButton = screen.getByRole('radio', { name: '초록' });
+      await user.click(greenColorButton);
+
+      // Then - 미리보기는 높이 80px의 div 요소
+      await waitFor(() => {
+        const preview = document.querySelector('div[style*="height: 80px"]');
+        // 초록: #519839 = rgb(81, 152, 57)
+        expect(preview).toHaveStyle({ backgroundColor: 'rgb(81, 152, 57)' });
+      });
+    });
+
+    it('선택된 색상에 체크 아이콘이 표시된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      const orangeColorButton = screen.getByRole('radio', { name: '주황' });
+      await user.click(orangeColorButton);
+
+      // Then
+      expect(orangeColorButton).toHaveAttribute('aria-checked', 'true');
+      const checkIcon = orangeColorButton.querySelector('svg');
+      expect(checkIcon).toBeInTheDocument();
+    });
+  });
+
+  describe('모달 닫기', () => {
+    it('닫기 버튼 클릭 시 onClose가 호출된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      await user.click(screen.getByRole('button', { name: '닫기' }));
+
+      // Then
+      expect(props.onClose).toHaveBeenCalled();
+    });
+
+    it('취소 버튼 클릭 시 onClose가 호출된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      await user.click(screen.getByRole('button', { name: '취소' }));
+
+      // Then
+      expect(props.onClose).toHaveBeenCalled();
+    });
+
+    it('ESC 키 입력 시 onClose가 호출된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      await user.keyboard('{Escape}');
+
+      // Then
+      expect(props.onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('보드 생성', () => {
+    it('폼 제출 시 API가 호출된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      mockApiClient.post.mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: mockBoardResponse,
+          timestamp: '2025-01-07T12:00:00.000Z',
+        },
+      });
+
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      const input = screen.getByLabelText(/보드 제목/);
+      await user.type(input, '새 프로젝트');
+      await user.click(screen.getByRole('button', { name: '만들기' }));
+
+      // Then
+      await waitFor(() => {
+        expect(mockApiClient.post).toHaveBeenCalledWith('/boards', {
+          title: '새 프로젝트',
+          backgroundColor: DEFAULT_BOARD_COLOR,
+        });
+      });
+    });
+
+    it('생성 성공 시 onClose와 onSuccess가 호출된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      mockApiClient.post.mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: mockBoardResponse,
+          timestamp: '2025-01-07T12:00:00.000Z',
+        },
+      });
+
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      const input = screen.getByLabelText(/보드 제목/);
+      await user.type(input, '새 프로젝트');
+      await user.click(screen.getByRole('button', { name: '만들기' }));
+
+      // Then
+      await waitFor(() => {
+        expect(props.onClose).toHaveBeenCalled();
+      });
+      expect(props.onSuccess).toHaveBeenCalledWith(mockBoardResponse.id);
+    });
+
+    it('생성 성공 시 해당 보드 페이지로 이동한다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      mockApiClient.post.mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: mockBoardResponse,
+          timestamp: '2025-01-07T12:00:00.000Z',
+        },
+      });
+
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      const input = screen.getByLabelText(/보드 제목/);
+      await user.type(input, '새 프로젝트');
+      await user.click(screen.getByRole('button', { name: '만들기' }));
+
+      // Then
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          `/boards/${mockBoardResponse.id}`,
+        );
+      });
+    });
+
+    it('생성 중 로딩 상태가 표시된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      let resolvePromise: (value: any) => void;
+      const pendingPromise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+      mockApiClient.post.mockReturnValueOnce(pendingPromise as any);
+
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      const input = screen.getByLabelText(/보드 제목/);
+      await user.type(input, '새 프로젝트');
+      await user.click(screen.getByRole('button', { name: '만들기' }));
+
+      // Then
+      await waitFor(() => {
+        expect(screen.getByText('생성 중...')).toBeInTheDocument();
+      });
+
+      // Cleanup
+      resolvePromise!({
+        data: {
+          success: true,
+          data: mockBoardResponse,
+          timestamp: '2025-01-07T12:00:00.000Z',
+        },
+      });
+    });
+
+    it('생성 중에는 모달을 닫을 수 없다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      let resolvePromise: (value: any) => void;
+      const pendingPromise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+      mockApiClient.post.mockReturnValueOnce(pendingPromise as any);
+
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      const input = screen.getByLabelText(/보드 제목/);
+      await user.type(input, '새 프로젝트');
+      await user.click(screen.getByRole('button', { name: '만들기' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('생성 중...')).toBeInTheDocument();
+      });
+
+      // 닫기 버튼 클릭 시도
+      await user.click(screen.getByRole('button', { name: '닫기' }));
+
+      // Then
+      expect(props.onClose).not.toHaveBeenCalled();
+
+      // Cleanup
+      resolvePromise!({
+        data: {
+          success: true,
+          data: mockBoardResponse,
+          timestamp: '2025-01-07T12:00:00.000Z',
+        },
+      });
+    });
+
+    it('생성 실패 시 에러 메시지가 표시된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      mockApiClient.post.mockRejectedValueOnce(new Error('Network Error'));
+
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      const input = screen.getByLabelText(/보드 제목/);
+      await user.type(input, '새 프로젝트');
+      await user.click(screen.getByRole('button', { name: '만들기' }));
+
+      // Then
+      await waitFor(() => {
+        expect(
+          screen.getByText('보드 생성에 실패했습니다. 다시 시도해주세요.'),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('접근성', () => {
+    it('모달에 role="dialog"가 설정된다', () => {
+      // Given
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      // When
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // Then
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('제목 입력 필드에 aria-required가 설정된다', () => {
+      // Given
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+
+      // When
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // Then
+      const input = screen.getByLabelText(/보드 제목/);
+      expect(input).toHaveAttribute('aria-required', 'true');
+    });
+
+    it('에러 발생 시 aria-invalid가 true로 설정된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      const input = screen.getByLabelText(/보드 제목/);
+      await user.type(input, 'a'.repeat(101));
+
+      // Then
+      await waitFor(() => {
+        expect(input).toHaveAttribute('aria-invalid', 'true');
+      });
+    });
+
+    it('에러 메시지에 role="alert"가 설정된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+      render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // When
+      const input = screen.getByLabelText(/보드 제목/);
+      await user.type(input, 'a'.repeat(101));
+
+      // Then
+      await waitFor(() => {
+        const errorMessage = screen.getByRole('alert');
+        expect(errorMessage).toHaveTextContent(
+          '보드 제목은 100자 이하로 입력해주세요.',
+        );
+      });
+    });
+  });
+
+  describe('폼 초기화', () => {
+    it('모달이 다시 열릴 때 폼이 초기화된다', async () => {
+      // Given
+      const user = userEvent.setup();
+      const props = createDefaultProps();
+      const Wrapper = createWrapper();
+      const { rerender } = render(
+        <Wrapper>
+          <CreateBoardModal {...props} />
+        </Wrapper>,
+      );
+
+      // 제목 입력
+      const input = screen.getByLabelText(/보드 제목/);
+      await user.type(input, '테스트 보드');
+      expect(input).toHaveValue('테스트 보드');
+
+      // 모달 닫기
+      rerender(
+        <Wrapper>
+          <CreateBoardModal {...props} isOpen={false} />
+        </Wrapper>,
+      );
+
+      // When - 모달 다시 열기
+      rerender(
+        <Wrapper>
+          <CreateBoardModal {...props} isOpen />
+        </Wrapper>,
+      );
+
+      // Then
+      const resetInput = screen.getByLabelText(/보드 제목/);
+      expect(resetInput).toHaveValue('');
+    });
+  });
+});

--- a/apps/web/src/domains/boards/constants/colors.ts
+++ b/apps/web/src/domains/boards/constants/colors.ts
@@ -1,0 +1,19 @@
+/**
+ * 보드 배경색 프리셋
+ * 보드 생성/수정 시 선택 가능한 색상 목록
+ */
+export const BOARD_COLOR_PRESETS = [
+  { id: 'blue', value: '#0079BF', label: '파랑' },
+  { id: 'orange', value: '#D29034', label: '주황' },
+  { id: 'green', value: '#519839', label: '초록' },
+  { id: 'red', value: '#B04632', label: '빨강' },
+  { id: 'purple', value: '#89609E', label: '보라' },
+  { id: 'pink', value: '#CD5A91', label: '분홍' },
+] as const;
+
+export type BoardColorPreset = (typeof BOARD_COLOR_PRESETS)[number];
+export type BoardColorId = BoardColorPreset['id'];
+export type BoardColorValue = BoardColorPreset['value'];
+
+/** 기본 선택 색상 (첫 번째 색상) */
+export const DEFAULT_BOARD_COLOR = BOARD_COLOR_PRESETS[0].value;

--- a/apps/web/src/domains/boards/hooks/__tests__/useCreateBoard.test.tsx
+++ b/apps/web/src/domains/boards/hooks/__tests__/useCreateBoard.test.tsx
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import {
+  useCreateBoard,
+  type CreateBoardInput,
+} from '@/domains/boards/hooks/useCreateBoard';
+import apiClient from '@/lib/api/api-client';
+
+// apiClient 모킹
+vi.mock('@/lib/api/api-client', () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+const mockApiClient = vi.mocked(apiClient);
+
+describe('useCreateBoard', () => {
+  let queryClient: QueryClient;
+
+  const createWrapper = () => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    return function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+    };
+  };
+
+  const mockBoardInput: CreateBoardInput = {
+    title: '새 프로젝트 보드',
+    backgroundColor: '#0079BF',
+  };
+
+  const mockBoardResponse = {
+    id: 'board-123',
+    title: '새 프로젝트 보드',
+    backgroundColor: '#0079BF',
+    createdAt: '2025-01-07T12:00:00.000Z',
+    updatedAt: '2025-01-07T12:00:00.000Z',
+    lastAccessedAt: null,
+    listsCount: 0,
+    cardsCount: 0,
+    members: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  describe('성공 케이스', () => {
+    it('보드 생성 요청이 성공하면 생성된 보드 데이터를 반환한다', async () => {
+      // Given
+      mockApiClient.post.mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: mockBoardResponse,
+          timestamp: '2025-01-07T12:00:00.000Z',
+        },
+      });
+
+      const { result } = renderHook(() => useCreateBoard(), {
+        wrapper: createWrapper(),
+      });
+
+      // When
+      result.current.mutate(mockBoardInput);
+
+      // Then
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(mockBoardResponse);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        '/boards',
+        mockBoardInput,
+      );
+    });
+
+    it('보드 생성 성공 시 boards 쿼리가 무효화된다', async () => {
+      // Given
+      mockApiClient.post.mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: mockBoardResponse,
+          timestamp: '2025-01-07T12:00:00.000Z',
+        },
+      });
+
+      // createWrapper()를 먼저 호출하여 queryClient를 생성한 후 spy 설정
+      const wrapper = createWrapper();
+      const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+      const { result } = renderHook(() => useCreateBoard(), {
+        wrapper,
+      });
+
+      // When
+      result.current.mutate(mockBoardInput);
+
+      // Then
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ['boards'],
+      });
+    });
+  });
+
+  describe('실패 케이스', () => {
+    it('API 응답이 success: false일 때 에러가 발생한다', async () => {
+      // Given
+      mockApiClient.post.mockResolvedValueOnce({
+        data: {
+          success: false,
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: '보드 제목이 유효하지 않습니다.',
+          },
+          timestamp: '2025-01-07T12:00:00.000Z',
+        },
+      });
+
+      const { result } = renderHook(() => useCreateBoard(), {
+        wrapper: createWrapper(),
+      });
+
+      // When
+      result.current.mutate(mockBoardInput);
+
+      // Then
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error?.message).toBe(
+        '보드 제목이 유효하지 않습니다.',
+      );
+    });
+
+    it('네트워크 에러 발생 시 에러 상태가 된다', async () => {
+      // Given
+      mockApiClient.post.mockRejectedValueOnce(new Error('Network Error'));
+
+      const { result } = renderHook(() => useCreateBoard(), {
+        wrapper: createWrapper(),
+      });
+
+      // When
+      result.current.mutate(mockBoardInput);
+
+      // Then
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+    });
+  });
+
+  describe('상태 변화', () => {
+    it('mutation 실행 중 isPending이 true가 된다', async () => {
+      // Given
+      let resolvePromise: (value: unknown) => void;
+      const pendingPromise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+      mockApiClient.post.mockReturnValueOnce(pendingPromise as never);
+
+      const { result } = renderHook(() => useCreateBoard(), {
+        wrapper: createWrapper(),
+      });
+
+      // When
+      result.current.mutate(mockBoardInput);
+
+      // Then
+      await waitFor(() => {
+        expect(result.current.isPending).toBe(true);
+      });
+
+      // Cleanup
+      resolvePromise!({
+        data: {
+          success: true,
+          data: mockBoardResponse,
+          timestamp: '2025-01-07T12:00:00.000Z',
+        },
+      });
+
+      await waitFor(() => {
+        expect(result.current.isPending).toBe(false);
+      });
+    });
+
+    it('초기 상태는 idle이다', () => {
+      // Given & When
+      const { result } = renderHook(() => useCreateBoard(), {
+        wrapper: createWrapper(),
+      });
+
+      // Then
+      expect(result.current.isIdle).toBe(true);
+      expect(result.current.isPending).toBe(false);
+      expect(result.current.isSuccess).toBe(false);
+      expect(result.current.isError).toBe(false);
+    });
+  });
+
+  describe('mutateAsync', () => {
+    it('mutateAsync는 Promise를 반환한다', async () => {
+      // Given
+      mockApiClient.post.mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: mockBoardResponse,
+          timestamp: '2025-01-07T12:00:00.000Z',
+        },
+      });
+
+      const { result } = renderHook(() => useCreateBoard(), {
+        wrapper: createWrapper(),
+      });
+
+      // When
+      const board = await result.current.mutateAsync(mockBoardInput);
+
+      // Then
+      expect(board).toEqual(mockBoardResponse);
+    });
+
+    it('mutateAsync 실패 시 Promise가 reject된다', async () => {
+      // Given
+      mockApiClient.post.mockResolvedValueOnce({
+        data: {
+          success: false,
+          error: {
+            code: 'SERVER_ERROR',
+            message: '서버 오류가 발생했습니다.',
+          },
+          timestamp: '2025-01-07T12:00:00.000Z',
+        },
+      });
+
+      const { result } = renderHook(() => useCreateBoard(), {
+        wrapper: createWrapper(),
+      });
+
+      // When & Then
+      await expect(result.current.mutateAsync(mockBoardInput)).rejects.toThrow(
+        '서버 오류가 발생했습니다.',
+      );
+    });
+  });
+});

--- a/apps/web/src/domains/boards/hooks/useCreateBoard.ts
+++ b/apps/web/src/domains/boards/hooks/useCreateBoard.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+
+import apiClient from '@/lib/api/api-client';
+import type {
+  ApiSuccessResponse,
+  ApiErrorResponse,
+  BoardSummary,
+} from '@/domains/boards/hooks/useBoards';
+
+export interface CreateBoardInput {
+  title: string;
+  backgroundColor: string;
+}
+
+type CreateBoardResponse = ApiSuccessResponse<BoardSummary> | ApiErrorResponse;
+
+interface CreateBoardError {
+  code: string;
+  message: string;
+}
+
+/**
+ * 보드 생성 mutation hook
+ * 보드 생성 성공 시 boards 쿼리를 무효화하여 목록을 갱신합니다.
+ */
+export function useCreateBoard() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    BoardSummary,
+    AxiosError<{ error: CreateBoardError }>,
+    CreateBoardInput
+  >({
+    mutationFn: async (input: CreateBoardInput) => {
+      const response = await apiClient.post<CreateBoardResponse>(
+        '/boards',
+        input,
+      );
+
+      if (!response.data.success) {
+        throw new Error(response.data.error.message);
+      }
+
+      return response.data.data;
+    },
+    onSuccess: () => {
+      // 보드 목록 쿼리 무효화하여 최신 데이터 반영
+      queryClient.invalidateQueries({ queryKey: ['boards'] });
+    },
+  });
+}

--- a/apps/web/src/domains/boards/schemas/__tests__/createBoardSchema.test.ts
+++ b/apps/web/src/domains/boards/schemas/__tests__/createBoardSchema.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { createBoardSchema } from '../createBoardSchema';
+
+describe('createBoardSchema', () => {
+  describe('title 필드', () => {
+    it('유효한 제목으로 검증을 통과한다', () => {
+      // Given
+      const validData = {
+        title: '프로젝트 보드',
+        backgroundColor: '#0079BF',
+      };
+
+      // When
+      const result = createBoardSchema.safeParse(validData);
+
+      // Then
+      expect(result.success).toBe(true);
+    });
+
+    it('빈 문자열은 검증에 실패한다', () => {
+      // Given
+      const invalidData = {
+        title: '',
+        backgroundColor: '#0079BF',
+      };
+
+      // When
+      const result = createBoardSchema.safeParse(invalidData);
+
+      // Then
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          '보드 제목을 입력해주세요.',
+        );
+      }
+    });
+
+    it('100자 이하 제목은 검증을 통과한다', () => {
+      // Given
+      const validData = {
+        title: 'a'.repeat(100),
+        backgroundColor: '#0079BF',
+      };
+
+      // When
+      const result = createBoardSchema.safeParse(validData);
+
+      // Then
+      expect(result.success).toBe(true);
+    });
+
+    it('100자 초과 제목은 검증에 실패한다', () => {
+      // Given
+      const invalidData = {
+        title: 'a'.repeat(101),
+        backgroundColor: '#0079BF',
+      };
+
+      // When
+      const result = createBoardSchema.safeParse(invalidData);
+
+      // Then
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          '보드 제목은 100자 이하로 입력해주세요.',
+        );
+      }
+    });
+
+    it('공백만 있는 제목도 유효한 것으로 처리된다 (trim 없음)', () => {
+      // Given
+      const data = {
+        title: '   ',
+        backgroundColor: '#0079BF',
+      };
+
+      // When
+      const result = createBoardSchema.safeParse(data);
+
+      // Then
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('backgroundColor 필드', () => {
+    it('HEX 색상 값으로 검증을 통과한다', () => {
+      // Given
+      const validData = {
+        title: '테스트 보드',
+        backgroundColor: '#FF5733',
+      };
+
+      // When
+      const result = createBoardSchema.safeParse(validData);
+
+      // Then
+      expect(result.success).toBe(true);
+    });
+
+    it('임의의 문자열도 검증을 통과한다 (string 타입만 검사)', () => {
+      // Given
+      const data = {
+        title: '테스트 보드',
+        backgroundColor: 'not-a-color',
+      };
+
+      // When
+      const result = createBoardSchema.safeParse(data);
+
+      // Then
+      expect(result.success).toBe(true);
+    });
+
+    it('빈 문자열도 검증을 통과한다', () => {
+      // Given
+      const data = {
+        title: '테스트 보드',
+        backgroundColor: '',
+      };
+
+      // When
+      const result = createBoardSchema.safeParse(data);
+
+      // Then
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('필수 필드 검증', () => {
+    it('title이 누락되면 검증에 실패한다', () => {
+      // Given
+      const invalidData = {
+        backgroundColor: '#0079BF',
+      };
+
+      // When
+      const result = createBoardSchema.safeParse(invalidData);
+
+      // Then
+      expect(result.success).toBe(false);
+    });
+
+    it('backgroundColor가 누락되면 검증에 실패한다', () => {
+      // Given
+      const invalidData = {
+        title: '테스트 보드',
+      };
+
+      // When
+      const result = createBoardSchema.safeParse(invalidData);
+
+      // Then
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/domains/boards/schemas/createBoardSchema.ts
+++ b/apps/web/src/domains/boards/schemas/createBoardSchema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+const TITLE_MIN_LENGTH = 1;
+const TITLE_MAX_LENGTH = 100;
+
+export const createBoardSchema = z.object({
+  title: z
+    .string()
+    .min(TITLE_MIN_LENGTH, '보드 제목을 입력해주세요.')
+    .max(TITLE_MAX_LENGTH, '보드 제목은 100자 이하로 입력해주세요.'),
+  backgroundColor: z.string(),
+});
+
+export type CreateBoardFormData = z.infer<typeof createBoardSchema>;


### PR DESCRIPTION
<div align="center"><img src="https://github.com/user-attachments/assets/08efc8b7-e17a-4e02-8276-9a112381d4ad" width="320px" /></div>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements board creation via a modal with title input, background color selection, and live preview, wired to create and navigate to the new board.
> 
> - New `CreateBoardModal` (Headless UI `Dialog`) with `react-hook-form` + Zod (`createBoardSchema`) validation, live `BoardPreview`, and `ColorPicker` (6 presets; ARIA-friendly)
> - Adds `useCreateBoard` mutation (POST `/boards`) returning `BoardSummary` and invalidating `['boards']` on success; integrates in `CreateBoardButton`
> - Comprehensive tests for `CreateBoardModal`, `ColorPicker`, `BoardPreview`, `useCreateBoard`, and schema
> - Introduces color constants in `constants/colors.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7adda238bf95b7296d7d5e25c9634520db172af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 보드 생성 모달 추가: 제목 입력, 배경색 선택, 생성 시 이동 및 콜백 지원
  * 색상 선택 UI 추가: 6가지 사전정의 색상, 키보드/스크린리더 접근성 지원
  * 실시간 색상 미리보기 추가

* **유효성 검사**
  * 보드 제목 길이 제약 및 클라이언트 검증 추가

* **Tests**
  * 보드 생성, 색상 선택, 폼 검증 등 포괄적 테스트 스위트 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->